### PR TITLE
Set up FastAPI project structure

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.env
+venv/

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,45 @@
+# FastAPI Project
+
+## Setup Instructions
+
+1. Create a virtual environment for the project:
+   ```bash
+   python -m venv venv
+   ```
+
+2. Activate the virtual environment:
+   - On Windows:
+     ```bash
+     .\venv\Scripts\activate
+     ```
+   - On macOS and Linux:
+     ```bash
+     source venv/bin/activate
+     ```
+
+3. Install FastAPI and Uvicorn:
+   ```bash
+   pip install fastapi uvicorn
+   ```
+
+## Running the FastAPI Application
+
+1. Navigate to the `app` directory:
+   ```bash
+   cd app
+   ```
+
+2. Run the FastAPI application using Uvicorn:
+   ```bash
+   uvicorn main:app --reload
+   ```
+
+3. Open your browser and go to `http://127.0.0.1:8000` to see the "Hello World" message.
+
+## Testing Instructions
+
+You can test the "Hello World" endpoint using curl:
+
+```bash
+curl -X GET "http://127.0.0.1:8000/"
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the directory a package

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello World"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
Fixes #1

Set up the FastAPI project structure with basic functionality and documentation.

* Add `app/main.py` with a basic "Hello World" endpoint and a conditional to run the app with `uvicorn`.
* Add `app/__init__.py` to make the directory a package.
* Add `app/.gitignore` to exclude `__pycache__/`, `.env`, and `venv/`.
* Add `app/README.md` with instructions to set up the project, steps to run the FastAPI application, and testing instructions using curl.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/realsanket/copilot-workspace-test-1/pull/3?shareId=4e34eb13-e949-4348-bab9-ec6fb4236489).