### PR TITLE
Fetch and filter data from JSONPlaceholder API in FastAPI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,31 @@
 from fastapi import FastAPI
+import httpx
+import logging
 
 app = FastAPI()
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 @app.get("/")
 def read_root():
     return {"message": "Hello World"}
+
+@app.get("/posts/filtered")
+async def get_filtered_posts():
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get("https://jsonplaceholder.typicode.com/posts")
+            response.raise_for_status()
+            posts = response.json()
+            filtered_posts = [post for post in posts if post["id"] > 30]
+            return filtered_posts
+    except httpx.HTTPStatusError as exc:
+        logger.error(f"HTTP error occurred: {exc}")
+        return {"error": "Failed to fetch posts"}
+    except Exception as exc:
+        logger.error(f"An error occurred: {exc}")
+        return {"error": "An unexpected error occurred"}
 
 if __name__ == "__main__":
     import uvicorn

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -1,0 +1,12 @@
+import pytest
+import httpx
+from httpx import AsyncClient
+from app.main import app
+
+@pytest.mark.asyncio
+async def test_get_filtered_posts():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.get("/posts/filtered")
+        assert response.status_code == 200
+        posts = response.json()
+        assert all(post["id"] > 30 for post in posts)


### PR DESCRIPTION
Fixes #2

Implement the `/posts/filtered` endpoint in FastAPI to fetch and filter posts from the JSONPlaceholder API.

* Import `httpx` for making HTTP requests and `logging` for debugging purposes in `app/main.py`.
* Add a new endpoint `/posts/filtered` to fetch and filter posts with `id > 30`.
* Implement error handling for API call failures and unexpected data formats.
* Add logging for debugging purposes.
* Write unit tests in `app/tests/test_main.py` to validate the filtering logic for posts with `id > 30`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/realsanket/copilot-workspace-test-1/pull/4?shareId=936ed2ab-cbe7-40e3-97d2-81399f992ed1).